### PR TITLE
Feature/add option for sql encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,31 @@ public ActionResult OnPostAsync()
 }
 ```
 
+## Encryption
+To use SqliteCache with encryption make sure you are using the corresponding providers for your target framework.
+E.g. for Net481: 
+* https://www.nuget.org/packages/SQLitePCLRaw.provider.sqlcipher/2.0.4
+* https://www.nuget.org/packages/SQLitePCLRaw.lib.e_sqlcipher/2.0.4
+* https://www.nuget.org/packages/sqlite-net-sqlcipher/1.8.116
+* https://www.nuget.org/packages/Microsoft.Data.Sqlite.Core/5.0.17
+
+And make sure to use the correct provider when registering Sqlite
+```csharp
+raw.SetProvider((ISQLite3Provider)new SQLite3Provider_e_sqlcipher());
+serviceCollectionAccess.AddSingleton<SqliteCache>();
+serviceCollectionAccess.AddSingleton<IDistributedCache, SqliteCache>(aServiceProvider => aServiceProvider.GetRequiredService<SqliteCache>());
+```
+
+then just configure SqliteCache with the PasswordOption
+```csharp
+serviceCollectionAccess.Configure<SqliteCacheOptions>(aSqliteCacheOptions =>
+{
+...
+    aSqliteCacheOptions.Password = password;
+...
+});
+```
+
 ## License
 
 SqliteCache is developed and maintained by Mahmoud Al-Qudsi of NeoSmart Technologies. The project is

--- a/README.md
+++ b/README.md
@@ -123,10 +123,8 @@ public ActionResult OnPostAsync()
 ## Encryption
 To use SqliteCache with encryption make sure you are using the corresponding providers for your target framework.
 E.g. for Net481: 
-* https://www.nuget.org/packages/SQLitePCLRaw.provider.sqlcipher/2.0.4
-* https://www.nuget.org/packages/SQLitePCLRaw.lib.e_sqlcipher/2.0.4
-* https://www.nuget.org/packages/sqlite-net-sqlcipher/1.8.116
-* https://www.nuget.org/packages/Microsoft.Data.Sqlite.Core/5.0.17
+* https://www.nuget.org/packages/SQLitePCLRaw.provider.sqlcipher/2.1.10
+* https://www.nuget.org/packages/SQLitePCLRaw.lib.e_sqlcipher/2.1.10
 
 And make sure to use the correct provider when registering Sqlite
 ```csharp

--- a/SqliteCache.Tests/BasicTests.cs
+++ b/SqliteCache.Tests/BasicTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
@@ -47,7 +48,7 @@ namespace NeoSmart.Caching.Sqlite.Tests
             return cacheDb;
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(null)]
         [DataRow("testPassword")]
         public async Task BasicSetGet(string password)
@@ -77,9 +78,11 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        public void ExpiredIgnored()
+        [DataRow(null)]
+        [DataRow("testPassword")]
+        public void ExpiredIgnored(string password)
         {
-            using (var cache = CreateDefault())
+            using (var cache = CreateDefault(true, password))
             {
                 cache.Set("hi there", DefaultEncoding.GetBytes("hello"),
                     new DistributedCacheEntryOptions()
@@ -90,9 +93,11 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        public void ExpiredRenewal()
+        [DataRow(null)]
+        [DataRow("testPassword")]
+        public void ExpiredRenewal(string password)
         {
-            using (var cache = CreateDefault())
+            using (var cache = CreateDefault(true, password))
             {
                 cache.Set("hi there", DefaultEncoding.GetBytes("hello"),
                     new DistributedCacheEntryOptions()
@@ -106,12 +111,14 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        public void ExpirationStoredInUtc()
+        [DataRow(null)]
+        [DataRow("testPassword")]
+        public void ExpirationStoredInUtc(string password)
         {
             var expiryUtc = DateTimeOffset.UtcNow.AddMinutes(-1);
             var expiryLocal = expiryUtc.ToOffset(TimeSpan.FromHours(5));
 
-            using (var cache = CreateDefault())
+            using (var cache = CreateDefault(true, password))
             {
                 cache.Set("key", DefaultEncoding.GetBytes("value"), new DistributedCacheEntryOptions
                 {
@@ -123,9 +130,11 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        public void DoubleDispose()
+        [DataRow(null)]
+        [DataRow("testPassword")]
+        public void DoubleDispose(string password)
         {
-            using (var cache = CreateDefault(true))
+            using (var cache = CreateDefault(true, password))
             {
                 cache.Dispose();
             }
@@ -133,9 +142,11 @@ namespace NeoSmart.Caching.Sqlite.Tests
 
 #if NETCOREAPP3_0_OR_GREATER
         [TestMethod]
-        public async Task AsyncDispose()
+        [DataRow(null)]
+        [DataRow("testPassword")]
+        public async Task AsyncDispose(string password)
         {
-            await using (var cache = CreateDefault(true))
+            await using (var cache = CreateDefault(true, password))
             {
                 await cache.SetAsync("foo", DefaultEncoding.GetBytes("hello"));
                 var bytes = await cache.GetAsync("foo");

--- a/SqliteCache.Tests/BasicTests.cs
+++ b/SqliteCache.Tests/BasicTests.cs
@@ -38,19 +38,21 @@ namespace NeoSmart.Caching.Sqlite.Tests
             }
         }
 
-        private SqliteCache CreateDefault(bool persistent = true)
+        private SqliteCache CreateDefault(bool persistent = true, string password = null)
         {
             var logger = new TestLogger<SqliteCache>();
             logger.LogInformation("Creating a connection to db {DbPath}", Configuration.CachePath);
-            var cacheDb = new SqliteCache(Configuration with { MemoryOnly = !persistent }, logger);
+            var cacheDb = new SqliteCache(Configuration with { MemoryOnly = !persistent, SqliteEncryptionPassword = password}, logger);
 
             return cacheDb;
         }
 
-        [TestMethod]
-        public async Task BasicSetGet()
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("testPassword")]
+        public async Task BasicSetGet(string password)
         {
-            using (var cache = CreateDefault(true))
+            using (var cache = CreateDefault(true, password))
             {
                 var bytes = cache.Get("hello");
                 Assert.IsNull(bytes);
@@ -67,7 +69,7 @@ namespace NeoSmart.Caching.Sqlite.Tests
             }
 
             // Check persistence
-            using (var cache = CreateDefault(true))
+            using (var cache = CreateDefault(true, password))
             {
                 var bytes = await cache.GetAsync("hello");
                 CollectionAssert.AreEqual(bytes, DefaultEncoding.GetBytes("hello"));

--- a/SqliteCache.Tests/BasicTests.cs
+++ b/SqliteCache.Tests/BasicTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
@@ -48,7 +47,7 @@ namespace NeoSmart.Caching.Sqlite.Tests
             return cacheDb;
         }
 
-        [TestMethod]
+        [DataTestMethod]
         [DataRow(null)]
         [DataRow("testPassword")]
         public async Task BasicSetGet(string password)
@@ -78,11 +77,9 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        [DataRow(null)]
-        [DataRow("testPassword")]
-        public void ExpiredIgnored(string password)
+        public void ExpiredIgnored()
         {
-            using (var cache = CreateDefault(true, password))
+            using (var cache = CreateDefault())
             {
                 cache.Set("hi there", DefaultEncoding.GetBytes("hello"),
                     new DistributedCacheEntryOptions()
@@ -93,11 +90,9 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        [DataRow(null)]
-        [DataRow("testPassword")]
-        public void ExpiredRenewal(string password)
+        public void ExpiredRenewal()
         {
-            using (var cache = CreateDefault(true, password))
+            using (var cache = CreateDefault())
             {
                 cache.Set("hi there", DefaultEncoding.GetBytes("hello"),
                     new DistributedCacheEntryOptions()
@@ -111,14 +106,12 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        [DataRow(null)]
-        [DataRow("testPassword")]
-        public void ExpirationStoredInUtc(string password)
+        public void ExpirationStoredInUtc()
         {
             var expiryUtc = DateTimeOffset.UtcNow.AddMinutes(-1);
             var expiryLocal = expiryUtc.ToOffset(TimeSpan.FromHours(5));
 
-            using (var cache = CreateDefault(true, password))
+            using (var cache = CreateDefault())
             {
                 cache.Set("key", DefaultEncoding.GetBytes("value"), new DistributedCacheEntryOptions
                 {
@@ -130,11 +123,9 @@ namespace NeoSmart.Caching.Sqlite.Tests
         }
 
         [TestMethod]
-        [DataRow(null)]
-        [DataRow("testPassword")]
-        public void DoubleDispose(string password)
+        public void DoubleDispose()
         {
-            using (var cache = CreateDefault(true, password))
+            using (var cache = CreateDefault(true))
             {
                 cache.Dispose();
             }
@@ -142,11 +133,9 @@ namespace NeoSmart.Caching.Sqlite.Tests
 
 #if NETCOREAPP3_0_OR_GREATER
         [TestMethod]
-        [DataRow(null)]
-        [DataRow("testPassword")]
-        public async Task AsyncDispose(string password)
+        public async Task AsyncDispose()
         {
-            await using (var cache = CreateDefault(true, password))
+            await using (var cache = CreateDefault(true))
             {
                 await cache.SetAsync("foo", DefaultEncoding.GetBytes("hello"));
                 var bytes = await cache.GetAsync("foo");

--- a/SqliteCache.Tests/BasicTests.cs
+++ b/SqliteCache.Tests/BasicTests.cs
@@ -38,21 +38,19 @@ namespace NeoSmart.Caching.Sqlite.Tests
             }
         }
 
-        private SqliteCache CreateDefault(bool persistent = true, string password = null)
+        private SqliteCache CreateDefault(bool persistent = true)
         {
             var logger = new TestLogger<SqliteCache>();
             logger.LogInformation("Creating a connection to db {DbPath}", Configuration.CachePath);
-            var cacheDb = new SqliteCache(Configuration with { MemoryOnly = !persistent, SqliteEncryptionPassword = password}, logger);
+            var cacheDb = new SqliteCache(Configuration with { MemoryOnly = !persistent }, logger);
 
             return cacheDb;
         }
 
-        [DataTestMethod]
-        [DataRow(null)]
-        [DataRow("testPassword")]
-        public async Task BasicSetGet(string password)
+        [TestMethod]
+        public async Task BasicSetGet()
         {
-            using (var cache = CreateDefault(true, password))
+            using (var cache = CreateDefault(true))
             {
                 var bytes = cache.Get("hello");
                 Assert.IsNull(bytes);
@@ -69,7 +67,7 @@ namespace NeoSmart.Caching.Sqlite.Tests
             }
 
             // Check persistence
-            using (var cache = CreateDefault(true, password))
+            using (var cache = CreateDefault(true))
             {
                 var bytes = await cache.GetAsync("hello");
                 CollectionAssert.AreEqual(bytes, DefaultEncoding.GetBytes("hello"));

--- a/SqliteCache/SqliteCacheOptions.cs
+++ b/SqliteCache/SqliteCacheOptions.cs
@@ -66,7 +66,7 @@ namespace NeoSmart.Caching.Sqlite
                 };
 
                 // only set the password option if the user actually set a Password
-                if (string.IsNullOrEmpty(SqliteEncryptionPassword))
+                if (!string.IsNullOrEmpty(SqliteEncryptionPassword))
                 {
                     sb.Password = SqliteEncryptionPassword;
                 }

--- a/SqliteCache/SqliteCacheOptions.cs
+++ b/SqliteCache/SqliteCacheOptions.cs
@@ -42,6 +42,9 @@ namespace NeoSmart.Caching.Sqlite
         /// <summary>
         /// Use this to specify a password for the SqliteConnection that is to be created.
         /// If no <see cref="SqliteEncryptionPassword"/> is set, the connectionStringBuilder will not use the "Password" option.
+        ///
+        /// CAREFUL! this option will break your SqliteConnection if the sqliteProvider that you are using does not support encryption.
+        /// You will have to use e.g. (SQLitePCLRaw.provider.sqlcipher) instead of (SQLitePCLRaw.provider.e_sqlite3)
         /// </summary>
         public string? SqliteEncryptionPassword { get; set; } = null;
 

--- a/SqliteCache/SqliteCacheOptions.cs
+++ b/SqliteCache/SqliteCacheOptions.cs
@@ -40,9 +40,10 @@ namespace NeoSmart.Caching.Sqlite
         }
 
         /// <summary>
-        /// 
+        /// Use this to specify a password for the SqliteConnection that is to be created.
+        /// If no <see cref="SqliteEncryptionPassword"/> is set, the connectionStringBuilder will not use the "Password" option.
         /// </summary>
-        public string SqliteEncryptionPassword { get; set; } = "";
+        public string? SqliteEncryptionPassword { get; set; } = null;
 
         /// <summary>
         /// Specifies how often expired items are removed in the background.
@@ -60,6 +61,8 @@ namespace NeoSmart.Caching.Sqlite
                     Mode = MemoryOnly ? SqliteOpenMode.Memory : SqliteOpenMode.ReadWriteCreate,
                     Cache = SqliteCacheMode.Shared
                 };
+
+                // only set the password option if the user actually set a Password
                 if (string.IsNullOrEmpty(SqliteEncryptionPassword))
                 {
                     sb.Password = SqliteEncryptionPassword;

--- a/SqliteCache/SqliteCacheOptions.cs
+++ b/SqliteCache/SqliteCacheOptions.cs
@@ -40,6 +40,11 @@ namespace NeoSmart.Caching.Sqlite
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        public string SqliteEncryptionPassword { get; set; } = "";
+
+        /// <summary>
         /// Specifies how often expired items are removed in the background.
         /// Background eviction is disabled if set to <c>null</c>.
         /// </summary>
@@ -55,6 +60,10 @@ namespace NeoSmart.Caching.Sqlite
                     Mode = MemoryOnly ? SqliteOpenMode.Memory : SqliteOpenMode.ReadWriteCreate,
                     Cache = SqliteCacheMode.Shared
                 };
+                if (string.IsNullOrEmpty(SqliteEncryptionPassword))
+                {
+                    sb.Password = SqliteEncryptionPassword;
+                }
 
                 return sb.ConnectionString;
             }


### PR DESCRIPTION
I saw you responding to an issue https://github.com/neosmart/SqliteCache/issues/18 by saying that you want to leave the security to the filesystem - would you be so kind as to explain this decision further?

We have the need to encrypt our sqlite database because multiple entites have access to the shared filesystem where multiple DB files are to be stored for the different user groups.

Please have a look at the changes and feel free to critique them - since this is my first ever attempt at contributing to an Open source project I am eager to learn the do's and dont's.

The tests are not actually encrypting the DB at the moment because we are not using a provider that supports it.
I just extended them to be able to verify that adding the Password-option does not break anything when using the classic sqlite providers.